### PR TITLE
HAB-84 : rending cutt off fix

### DIFF
--- a/src/Styles.css
+++ b/src/Styles.css
@@ -5,6 +5,7 @@
 body {
     background-color: #F9F9F9;
     width: auto;
+    padding-bottom: 100px;
 }
 
 .app {


### PR DESCRIPTION
Fix rendering bug where the menu would be cut off. This is due to setting the nav bar position as fixed which results in elements overlapping. Fixed with padding in the bottom of the body.