### PR TITLE
HAB 84 : goal edit

### DIFF
--- a/src/Utilities/editGoalButton.js
+++ b/src/Utilities/editGoalButton.js
@@ -1,0 +1,131 @@
+import React from 'react'
+import Grid from '@material-ui/core/Grid'
+import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogContentText from '@material-ui/core/DialogContentText'
+import TextField from '@material-ui/core/TextField'
+import MenuItem from '@material-ui/core/MenuItem'
+import DialogActions from '@material-ui/core/DialogActions'
+import axios from 'axios'
+
+export default function EditGoalButton(props) {
+    const [state, setState] = React.useState({
+        title: props.title,
+        start: '',
+        end: '',
+    });
+    const [isOpen, setOpen] = React.useState(false);
+
+    const handleChange = (event) => {
+        const name = event.target.name;
+        setState({
+            ...state,
+            [name]: event.target.value,
+        });
+    };
+
+
+
+    const handleSubmit = (e) => {
+        //post to back end
+        e.preventDefault();
+        let startSplit = state.start.split('-')
+        let start = `${startSplit[1]}-${startSplit[2]}-${startSplit[0]}`
+        let endSplit = state.end.split('-')
+        let end = `${endSplit[1]}-${endSplit[2]}-${endSplit[0]}`
+
+        let goal = { title: state.title, start: start, end: end }
+        console.log(goal);
+
+        axios
+            .delete(`/goal/${props.title}`)
+            .then((res) => {
+                console.log(res)
+            })
+            .catch((err) => {
+                console.log(err)
+
+            })
+        axios
+            .post("/goal", goal)
+            .then((res) => {
+                console.log(res)
+                window.location.reload();
+            })
+            .catch((err) => {
+                console.log(err)
+            })
+
+
+        setOpen(false);
+    }
+    const handleClickOpen = () => {
+        setOpen(true);
+    }
+    const handleClose = () => {
+        setOpen(false)
+    };
+
+    return (
+        <div >
+
+            <Grid item>
+                <Button size="small" color="primary" onClick={handleClickOpen}>
+                    Edit Goal
+                                            </Button>
+            </Grid>
+
+
+            <Dialog open={isOpen} onClose={handleClose} aria-labelledby="form-dialog-title">
+                <DialogTitle id="form-dialog-title">Edit Goal</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Update fields with new values
+                    </DialogContentText>
+                    <TextField
+                        autoFocus name="title"
+                        onChange={handleChange}
+                        margin="dense"
+                        id="title"
+                        label="title"
+                        type="string"
+                        value={state.title}
+                        fullWidth>
+
+                    </TextField>
+                     Start
+                   <TextField
+                        autoFocus
+                        margin="dense"
+                        id="start"
+                        type="date"
+                        name="start"
+                        fullWidth
+                        onChange={handleChange}
+                    />
+                                            End
+                                            <TextField
+                        autoFocus
+                        margin="dense"
+                        id="end"
+                        name="end"
+                        type="date"
+                        fullWidth
+                        onChange={handleChange}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose} color="primary">
+                        Cancel
+                                            </Button>
+                    <Button onClick={handleSubmit} color="primary">
+                        Save
+                                             </Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    )
+}
+

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -3,23 +3,17 @@
 
 import React, { Component } from 'react';
 //import React from 'react';
-import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Grid from '@material-ui/core/Grid';
-import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import Link from '@material-ui/core/Link';
 import MyBar from "../Utilities/myBar";
 import BottomNav from "../Utilities/myBotNav";
-import { FitnessCenter as workoutIcon } from '@material-ui/icons';
 import axios from "axios";
 import { authMiddleWare } from '../Utilities/auth'
 
@@ -30,6 +24,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DefaultGoal from '../Utilities/addDefault';
+import EditGoal from '../Utilities/editGoalButton';
 import defaultIMG from "../img/defaultIMG.png";
 import completeIMG from "../img/complete.png";
 import List from '@material-ui/core/List'
@@ -99,9 +94,9 @@ class home extends Component {
             .catch((err) => {
 
                 if (err.response.status == 403)
-                this.props.history.push('/')
-                 else
-                console.log(err)
+                    this.props.history.push('/')
+                else
+                    console.log(err)
             })
 
 
@@ -257,6 +252,12 @@ class home extends Component {
         })
     }
 
+
+    handleEditGoal(event) {
+        console.log(this.state.isOpen)
+    };
+
+
     handleDelete(index) {
         let id = this.state.goals[index].title
         console.log(id)
@@ -268,16 +269,18 @@ class home extends Component {
 
     }
 
+
+
     handleDeleteSave() {
         let length = this.state.deleteArr.length
-        
+
         this.state.deleteArr.map(goal => {
             axios
                 .delete(`/goal/${goal}`)
                 .then((res) => {
                     console.log(res)
                     --length
-                    if(!length){
+                    if (!length) {
                         window.location.reload()
                     }
                 })
@@ -290,13 +293,13 @@ class home extends Component {
             deleteOpen: false
         })
         console.log(length)
-        if(length === 0){
+        if (length === 0) {
             window.location.reload()
         }
 
     }
 
-    
+
     componentDidUpdate() {
         console.log(this.state.deleteArr)
     }
@@ -395,8 +398,8 @@ class home extends Component {
                                         </Dialog>
                                         <Dialog open={this.state.deleteOpen} onClose={this.handleClose} aria-labelledby="form-dialog-title">
                                             <DialogContent >
-                                            <DialogContentText>
-                                                                                Press save to delete goals highlighted red, press cancel to keep goals
+                                                <DialogContentText>
+                                                    Press save to delete goals highlighted red, press cancel to keep goals
                                                                              </DialogContentText>
                                                 <div style={{ flexGrow: '1', maxWidth: '752' }}>
                                                     <Grid container spacing={2}  >
@@ -426,7 +429,7 @@ class home extends Component {
                                                     Cancel
                                             </Button>
                                                 <Button onClick={this.handleDeleteSave} color="primary">
-                                                    Save
+                                                    Confirm
                                              </Button>
                                             </DialogActions>
                                         </Dialog>
@@ -458,9 +461,7 @@ class home extends Component {
                                                 <Button onClick={() => this.handleCompleteGoal(index)} size="small" color="primary">
                                                     Complete
                                                 </Button>
-                                                <Button size="small" color="primary">
-                                                    Edit
-                                                </Button>
+                                                <EditGoal title={goal.title} />
                                                 <form name={goal.title} onSubmit={this.handlePicSubmit} >
                                                     <Button type="submit" size="small" color="primary">Submit</Button>
                                                     <input type="file" onChange={this.getPic} />


### PR DESCRIPTION
Partial goal edit functionality: A pop-up form is displayed with the current goal title and the user can update it and set dates. Since it is a few days before deployment Felix and I thought it would be best to play it safe and not try to make new API routes so this method deletes the old goal and makes a new one ( any data in the array or image URLs will not be copied over ). However maybe an easy fix if able to pass multiple arguments as props, I will keep trying but not sure if I will get around to it before deployment.